### PR TITLE
feat: add [i] checkbox support in render-markdown

### DIFF
--- a/neovim/neobean/lua/plugins/render-markdown.lua
+++ b/neovim/neobean/lua/plugins/render-markdown.lua
@@ -102,6 +102,9 @@ return {
         -- Highlight for item associated with checked checkbox
         scope_highlight = nil,
       },
+      custom = {
+        todo = { raw = "[i]", rendered = "   󰡌 ", highlight = "RenderMarkdownTodo" },
+      },
     },
     html = {
       -- Turn on / off all HTML rendering


### PR DESCRIPTION
Add custom [i] checkbox with info icon (󰡌) for informational tasks. Enhances task management with additional checkbox type beyond [ ] and [x].