### PR TITLE
feat: include all Hosts instead of just the first

### DIFF
--- a/tmux/tools/linkarzu/ssh_config_select.sh
+++ b/tmux/tools/linkarzu/ssh_config_select.sh
@@ -30,7 +30,7 @@ fi
 fzf_header=$'Select an SSH host to connect to:'
 
 # Use fzf to select a host
-selected_host=$(awk '/^Host / && !/\*/ {print $2}' "$ssh_config" | fzf --height=40% --reverse --header="$fzf_header" --prompt="Type or select SSH host: ")
+selected_host=$(awk '/^Host / && !/\*/ {for (i=2; i<=NF; i++) print $i}' "$ssh_config" | fzf --height=40% --reverse --header="$fzf_header" --prompt="Type or select SSH host: ")
 
 # Exit if no selection is made
 if [[ -z $selected_host ]]; then


### PR DESCRIPTION
This allows selection of Host by multiple aliases defined like this:

```ini
Host server-user user-server other-alias
 HostName my.server.com
 Port 22
 User username
 IdentityFile ~/.ssh/keys/id_ed25519
```
